### PR TITLE
add support for hexiwear spi flash

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -24,6 +24,12 @@
             "SPI_MISO": "p21",
             "SPI_CLK":  "p19",
             "SPI_CS":   "p17"
+        },
+        "HEXIWEAR": {
+             "SPI_MOSI": "PTD6",
+             "SPI_MISO": "PTD7",
+             "SPI_CLK":  "PTD5",
+             "SPI_CS":   "PTD4"
         }
     }
 }


### PR DESCRIPTION
Add pin connections for internal spi flash in NXP Hexiwear.  

Tested with mbed-os-example-spiflash-driver application.

```
spif test
spif size: 8388608
spif read size: 1
spif program size: 1
spif erase size: 4096
Hello World!
```


 