### PR TITLE
Add option to specify SPI frequency

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -4,7 +4,8 @@
         "SPI_MOSI": "NC",
         "SPI_MISO": "NC",
         "SPI_CLK":  "NC",
-        "SPI_CS":   "NC"
+        "SPI_CS":   "NC",
+        "SPI_FREQ": "40000000"
     },
     "target_overrides": {
         "K82F": {


### PR DESCRIPTION
required for MTB_ADV_WISE_1570 where the default 40MHz frequency does not work.