### PR TITLE
Implement the get_erase_size API (based on address)

### DIFF
--- a/SPIFBlockDevice.cpp
+++ b/SPIFBlockDevice.cpp
@@ -329,6 +329,11 @@ bd_size_t SPIFBlockDevice::get_erase_size() const
     return SPIF_SE_SIZE;
 }
 
+bd_size_t SPIFBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return SPIF_SE_SIZE;
+}
+
 bd_size_t SPIFBlockDevice::size() const
 {
     return _size;

--- a/SPIFBlockDevice.h
+++ b/SPIFBlockDevice.h
@@ -130,6 +130,14 @@ public:
      */
     virtual bd_size_t get_erase_size() const;
 
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+
     /** Get the value of storage when erased
      *
      *  If get_erase_value returns a non-negative byte value, the underlying


### PR DESCRIPTION
Description:
Implemented the `get_erase_size(bd_addr_t addr)` API (one depending on address).
Fixes the warning described in issue [#35](https://github.com/ARMmbed/storage-selector/issues/35) of storage_selector repo.