### PR TITLE
Add some logic related to initialization

### DIFF
--- a/SPIFBlockDevice.h
+++ b/SPIFBlockDevice.h
@@ -163,6 +163,9 @@ private:
     // Device configuration discovered through sfdp
     bd_size_t _size;
 
+    bool _is_initialized;
+    uint32_t _init_ref_count;
+
     // Internal functions
     int _wren();
     int _sync();


### PR DESCRIPTION
- Add an initialization flag on which read/program/erase actions depend.
- Add an init reference count.

Resolves [#7455](https://github.com/ARMmbed/mbed-os/issues/7455).
Tested on K82F.