### PR TITLE
Use parenthesis to clarify the precedence of operators instead of rel…

### DIFF
--- a/SPIFBlockDevice.cpp
+++ b/SPIFBlockDevice.cpp
@@ -168,7 +168,7 @@ void SPIFBlockDevice::_cmdread(
     _spi.write(op);
 
     for (uint32_t i = 0; i < addrc; i++) {
-        _spi.write(0xff & (addr >> 8*(addrc-1 - i)));
+        _spi.write(0xff & (addr >> (8 * (addrc - 1 - i))));
     }
 
     for (uint32_t i = 0; i < retc; i++) {
@@ -180,7 +180,7 @@ void SPIFBlockDevice::_cmdread(
         printf("spif <- %02x", op);
         for (uint32_t i = 0; i < addrc; i++) {
             if (i < addrc) {
-                printf("%02lx", 0xff & (addr >> 8*(addrc-1 - i)));
+                printf("%02lx", 0xff & (addr >> (8 * (addrc - 1 - i))));
             } else {
                 printf("  ");
             }
@@ -204,7 +204,7 @@ void SPIFBlockDevice::_cmdwrite(
     _spi.write(op);
 
     for (uint32_t i = 0; i < addrc; i++) {
-        _spi.write(0xff & (addr >> 8*(addrc-1 - i)));
+        _spi.write(0xff & (addr >> (8 * (addrc - 1 - i))));
     }
 
     for (uint32_t i = 0; i < argc; i++) {
@@ -216,7 +216,7 @@ void SPIFBlockDevice::_cmdwrite(
         printf("spif -> %02x", op);
         for (uint32_t i = 0; i < addrc; i++) {
             if (i < addrc) {
-                printf("%02lx", 0xff & (addr >> 8*(addrc-1 - i)));
+                printf("%02lx", 0xff & (addr >> (8 * (addrc - 1 - i))));
             } else {
                 printf("  ");
             }


### PR DESCRIPTION
…ying on non-uniform spacing.

Maybe I'm a bit of a nitpicker, but relying on the precedence of operators like that make me wonder what was going on for a few minutes. Since it only costs a few parenthesis and spaces to avoid that, I fixed it.