### PR TITLE
Adding deprecation warning for mbed-os 5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Warning
+Starting from mbed-os 5.10 this repository is deprecated. 
+Please refer to mbed-os 5.10 documentation for more detail on how to enable SPIF support.
+
 # SPI Flash Driver
 
 Block device driver for NOR based SPI flash devices that support SFDP.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warning
 Starting from mbed-os 5.10 this repository is deprecated. 
-Please refer to mbed-os 5.10 documentation for more detail on how to enable SPIF support.
+Please refer to mbed-os 5.10 [documentation](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/api/storage/SPIFBlockDevice.md) and [code](https://github.com/ARMmbed/mbed-os/tree/master/components/storage/blockdevice/COMPONENT_SPIF) for more detail on how to enable SPIF support.
 
 # SPI Flash Driver
 

--- a/SPIFBlockDevice.cpp
+++ b/SPIFBlockDevice.cpp
@@ -22,6 +22,13 @@
 
 #include "mbed_trace.h"
 #define TRACE_GROUP "SPIF"
+
+/* Started from version 5.10.0 SPIFBlockDevice external repo is depricated. 
+   please use the SPIFBlockDevice component inside mbed-os.*/
+#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
+#error "Started from version 5.10.0 SPIFBlockDevice external repo is depricated. please use the SPIFBlockDevice component inside mbed-os."
+#endif
+
 using namespace mbed;
 
 /* Default SPIF Parameters */

--- a/SPIFBlockDevice.cpp
+++ b/SPIFBlockDevice.cpp
@@ -23,10 +23,10 @@
 #include "mbed_trace.h"
 #define TRACE_GROUP "SPIF"
 
-/* Started from version 5.10.0 SPIFBlockDevice external repo is depricated. 
+/* Started from version 5.10.0 SPIFBlockDevice external repo is deprecated. 
    please use the SPIFBlockDevice component inside mbed-os.*/
 #if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
-#error "Started from version 5.10.0 SPIFBlockDevice external repo is depricated. please use the SPIFBlockDevice component inside mbed-os."
+#error "Started from version 5.10.0 SPIFBlockDevice external repo is deprecated. please use the SPIFBlockDevice component inside mbed-os."
 #endif
 
 using namespace mbed;


### PR DESCRIPTION
Starting mbed-os 5.10 the SD driver has moved into mbed-os.
Therefore this PR is adding a warning in the SPIF documentation for the incoming depreciation. 

This PR is dependent on PR #7774
https://github.com/ARMmbed/mbed-os/pull/7774
